### PR TITLE
Use Blazor 0.8.0 preview

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Authors>Blazor Extensions Contributors</Authors>
     <Product>Blazor Extensions</Product>
     <Copyright>(c) Blazor Extensions Contributors. All rights reserved.</Copyright>
-    <PackageLicenseUrl>https://github.com/BlazorExtensions/Logging#license</PackageLicenseUrl>
+    <PackageLicense>https://github.com/BlazorExtensions/Logging#license</PackageLicense>
     <PackageProjectUrl>https://github.com/BlazorExtensions/Logging</PackageProjectUrl>
     <PackageIconUrl>https://avatars2.githubusercontent.com/u/38994076?s%3D128%26v%3D4</PackageIconUrl>
     <PackageTags>Microsoft ASP.NET Core Blazor Extensions Logging</PackageTags>
@@ -65,4 +65,11 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
+
+  <!-- Include preview Blazor bits -->
+  <PropertyGroup>
+    <RestoreAdditionalProjectSources>
+      https://dotnet.myget.org/f/blazor-dev/api/v3/index.json;
+    </RestoreAdditionalProjectSources>
+  </PropertyGroup>
 </Project>

--- a/src/Blazor.Extensions.Logging.JS/Blazor.Extensions.Logging.JS.csproj
+++ b/src/Blazor.Extensions.Logging.JS/Blazor.Extensions.Logging.JS.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Build" Version="0.8.0-preview1-20181126.4" />
     <WebpackInputs Include="**\*.ts" Exclude="dist\**;node_modules\**" />
   </ItemGroup>
 

--- a/src/Blazor.Extensions.Logging/Blazor.Extensions.Logging.csproj
+++ b/src/Blazor.Extensions.Logging/Blazor.Extensions.Logging.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Browser" Version="0.8.0-preview1-20181126.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
   </ItemGroup>
 

--- a/test/Blazor.Extensions.Logging.Test/Blazor.Extensions.Logging.Test.csproj
+++ b/test/Blazor.Extensions.Logging.Test/Blazor.Extensions.Logging.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <RunCommand>dotnet</RunCommand>
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.7.0" />
-    <DotNetCliToolReference Include="Microsoft.AspNetCore.Blazor.Cli" Version="0.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Browser" Version="0.8.0-preview1-20181126.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Build" Version="0.8.0-preview1-20181126.4" />
+    <DotNetCliToolReference Include="Microsoft.AspNetCore.Blazor.Cli" Version="0.8.0-preview1-20181126.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Blazor.Extensions.Logging.Test/Program.cs
+++ b/test/Blazor.Extensions.Logging.Test/Program.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Blazor.Hosting;
+using Microsoft.AspNetCore.Components.Hosting;
 
 namespace Blazor.Extensions.Logging.Test
 {

--- a/test/Blazor.Extensions.Logging.Test/Shared/MainLayout.cshtml
+++ b/test/Blazor.Extensions.Logging.Test/Shared/MainLayout.cshtml
@@ -1,4 +1,4 @@
-@inherits BlazorLayoutComponent
+@inherits LayoutComponentBase
 
 <div>
     @Body

--- a/test/Blazor.Extensions.Logging.Test/Startup.cs
+++ b/test/Blazor.Extensions.Logging.Test/Startup.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Blazor.Builder;
+using Microsoft.AspNetCore.Components.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 

--- a/test/Blazor.Extensions.Logging.Test/_ViewImports.cshtml
+++ b/test/Blazor.Extensions.Logging.Test/_ViewImports.cshtml
@@ -1,8 +1,7 @@
 @using System.Net.Http
-@using Microsoft.AspNetCore.Blazor
-@using Microsoft.AspNetCore.Blazor.Components
-@using Microsoft.AspNetCore.Blazor.Layouts
-@using Microsoft.AspNetCore.Blazor.Routing
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Layouts
+@using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.Extensions.Logging
 @using Blazor.Extensions.Logging
 @using Blazor.Extensions.Logging.Test


### PR DESCRIPTION
This is work required to make Logging extension work with Blazor 0.8.0 preview which is hybrid version between original Blazor and Razor Components based Blazor

This is change for informational purposes only, to serve as sample for those who want to try 0.8.0-preview bits of Blazor

I order to use pre-compiled version of this PR, you could add to you project file
```
  <PropertyGroup>
    <RestoreAdditionalProjectSources>
      https://dotnet.myget.org/f/blazor-dev/api/v3/index.json;
      https://www.myget.org/F/blazor-experiments/api/v3/index.json;
    </RestoreAdditionalProjectSources>
  </PropertyGroup>
```

Nuget was created using `dotnet pack Blazor.Extensions.Logging.csproj /p:Version=0.1.11-preview1 /p:Configuration=Release` to those who want to create package manually from branch