### PR TITLE
3.0.0-preview6 changes

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -8,7 +8,7 @@ steps:
   - task: DotNetCoreInstaller@0
     inputs:
       packageType: 'sdk'
-      version: '3.0.100-preview4-011223'
+      version: '3.0.100-preview6-012264'
 
   - task: Npm@1
     inputs:

--- a/.vsts-release.yml
+++ b/.vsts-release.yml
@@ -8,7 +8,7 @@ steps:
   - task: DotNetCoreInstaller@0
     inputs:
       packageType: 'sdk'
-      version: '3.0.100-preview4-011223'
+      version: '3.0.100-preview6-012264'
 
   - task: Npm@1
     inputs:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,8 +30,8 @@
 
   <!-- Versioning properties -->
   <PropertyGroup>
-    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">0.1.1</VersionPrefix>
-    <VersionSuffix Condition=" '$(VersionSuffix)'=='' ">dev</VersionSuffix>
+    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">3.0.0</VersionPrefix>
+    <VersionSuffix Condition=" '$(VersionSuffix)'=='' ">preview6</VersionSuffix>
   </PropertyGroup>
 
   <Choose>

--- a/Logging.sln
+++ b/Logging.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Blazor.Extensions.Logging",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8A34FDEB-D488-4AE3-887B-8254B33C7A13}"
 	ProjectSection(SolutionItems) = preProject
+		.vsts-ci.yml = .vsts-ci.yml
+		.vsts-release.yml = .vsts-release.yml
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		README.md = README.md

--- a/Logging.sln
+++ b/Logging.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28822.285
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{B286BCBD-DAD8-4DE7-9334-3DE18DF233AF}"
 EndProject
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Blazor.Extensions.Logging",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8A34FDEB-D488-4AE3-887B-8254B33C7A13}"
 	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/src/Blazor.Extensions.Logging.JS/Blazor.Extensions.Logging.JS.csproj
+++ b/src/Blazor.Extensions.Logging.JS/Blazor.Extensions.Logging.JS.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview4-19216-03" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview6.19307.2" PrivateAssets="all" />
     <WebpackInputs Include="**\*.ts" Exclude="dist\**;node_modules\**" />
   </ItemGroup>
 

--- a/src/Blazor.Extensions.Logging/Blazor.Extensions.Logging.csproj
+++ b/src/Blazor.Extensions.Logging/Blazor.Extensions.Logging.csproj
@@ -15,8 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Browser" Version="3.0.0-preview4-19216-03" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0-preview4.19216.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Browser" Version="3.0.0-preview6.19307.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0-preview6.19304.6" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Blazor.Extensions.Logging/FormattedLogObject.cs
+++ b/src/Blazor.Extensions.Logging/FormattedLogObject.cs
@@ -44,7 +44,7 @@ namespace Blazor.Extensions.Logging
             }
             else
             {
-                var isDataEnumerable = IsDataEnumerable(this.data);
+                var isDataEnumerable = this.IsDataEnumerable(this.data);
 
                 logObject = new LogObject
                 {
@@ -60,7 +60,7 @@ namespace Blazor.Extensions.Logging
             }
 
 #if !DESKTOP_BUILD
-            return Json.Serialize(logObject);
+            return Newtonsoft.Json.JsonConvert.SerializeObject(logObject);
 #else
             return JsonConvert.SerializeObject(logObject, new JsonSerializerSettings
             {

--- a/test/Blazor.Extensions.Logging.Test/Blazor.Extensions.Logging.Test.csproj
+++ b/test/Blazor.Extensions.Logging.Test/Blazor.Extensions.Logging.Test.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview4-19216-03" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview4-19216-03" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.DevServer" Version="3.0.0-preview4-19216-03" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview6.19307.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview6.19307.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.DevServer" Version="3.0.0-preview6.19307.2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Modest changes required for preview6 compatibility; Used Newtonsoft.Json rather than System.Text.Json after running into serialization/deserialization issues in another project. This can be revisited after System.Text.Json stabilizes.