### PR TITLE
Revert the addition of BrowserConsoleLoggerProvider from .Add back to .TryAddEnumerable

### DIFF
--- a/src/Blazor.Extensions.Logging/BrowserConsoleLoggerFactoryExtensions.cs
+++ b/src/Blazor.Extensions.Logging/BrowserConsoleLoggerFactoryExtensions.cs
@@ -12,7 +12,7 @@ namespace Blazor.Extensions.Logging
         /// </summary>
         public static ILoggingBuilder AddBrowserConsole(this ILoggingBuilder builder)
         {
-            builder.Services.Add(ServiceDescriptor.Singleton<ILoggerProvider, BrowserConsoleLoggerProvider>());
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, BrowserConsoleLoggerProvider>());
 
             // HACK: Override the hardcoded ILogger<> injected by Blazor
             builder.Services.Add(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(BrowserConsoleLogger<>)));


### PR DESCRIPTION
This change merely reverts to the behavior before the security & class change commit