### PR TITLE
BrowserConsoleLogger to handle different routing

### DIFF
--- a/src/Blazor.Extensions.Logging/BrowserConsoleLogger.cs
+++ b/src/Blazor.Extensions.Logging/BrowserConsoleLogger.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 

--- a/src/Blazor.Extensions.Logging/BrowserConsoleLogger.cs
+++ b/src/Blazor.Extensions.Logging/BrowserConsoleLogger.cs
@@ -8,11 +8,11 @@ namespace Blazor.Extensions.Logging
 {
     internal class BrowserConsoleLogger<T> : BrowserConsoleLogger, ILogger<T>
     {
-        public BrowserConsoleLogger (IJSRuntime jsRuntime) : base (jsRuntime, typeof (T).FullName, null)
+        public BrowserConsoleLogger (IJSRuntime jsRuntime, NavigationManager navigationManager) : base (jsRuntime, navigationManager, typeof (T).FullName, null)
         {
         }
 
-        public BrowserConsoleLogger (IJSRuntime jsRuntime, Func<string, LogLevel, bool> filter) : base (jsRuntime, typeof (T).FullName, filter)
+        public BrowserConsoleLogger (IJSRuntime jsRuntime, NavigationManager navigationManager, Func<string, LogLevel, bool> filter) : base (jsRuntime, navigationManager, typeof (T).FullName, filter)
         {
 
         }
@@ -21,20 +21,20 @@ namespace Blazor.Extensions.Logging
     internal class BrowserConsoleLogger : ILogger, IAsyncDisposable
     {
         private const string LoggerFunctionName = "log";
-        private const string ScriptName = "./_content/Blazor.Extensions.Logging/BrowserConsoleLogger.js";
+        private const string ScriptName = "_content/Blazor.Extensions.Logging/BrowserConsoleLogger.js";
 
         private readonly Lazy<Task<IJSObjectReference>> moduleTask;
         private IJSObjectReference module;
         private Func<string, LogLevel, bool> filter;
 
-        public BrowserConsoleLogger (IJSRuntime jsRuntime, string name, Func<string, LogLevel, bool> filter)
+        public BrowserConsoleLogger (IJSRuntime jsRuntime, NavigationManager navigationManager, string name, Func<string, LogLevel, bool> filter)
         {
             this.filter = filter ?? ((category, logLevel) => true);
             this.Name = name ??
                 throw new ArgumentNullException (nameof (name));
 
             this.moduleTask = new (() => jsRuntime.InvokeAsync<IJSObjectReference>(
-                "import", ScriptName).AsTask());
+                "import", navigationManager.ToAbsoluteUri(ScriptName)).AsTask());
         }
 
         public async void Log<TState> (LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)

--- a/src/Blazor.Extensions.Logging/BrowserConsoleLoggerProvider.cs
+++ b/src/Blazor.Extensions.Logging/BrowserConsoleLoggerProvider.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 using System;
 using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Components;
 
 namespace Blazor.Extensions.Logging
 {
@@ -12,11 +13,13 @@ namespace Blazor.Extensions.Logging
 
         private readonly Func<string, LogLevel, bool> filter;
         private readonly IJSRuntime runtime;
+        private readonly NavigationManager navigation;
         private ConcurrentDictionary<string, BrowserConsoleLogger> loggers;
 
-        public BrowserConsoleLoggerProvider(IJSRuntime runtime)
+        public BrowserConsoleLoggerProvider(IJSRuntime runtime, NavigationManager navigation)
         {
             this.runtime = runtime;
+            this.navigation = navigation;
         }
 
         public BrowserConsoleLoggerProvider(Func<string, LogLevel, bool> filter)
@@ -41,7 +44,7 @@ namespace Blazor.Extensions.Logging
 
         public void Dispose() => this.loggers?.Clear();
 
-        private BrowserConsoleLogger CreateLoggerImplementation(string name) => new BrowserConsoleLogger(this.runtime, name, this.GetFilter(name));
+        private BrowserConsoleLogger CreateLoggerImplementation(string name) => new BrowserConsoleLogger(this.runtime, navigation, name, this.GetFilter(name));
 
         private Func<string, LogLevel, bool> GetFilter(string name)
         {


### PR DESCRIPTION
In some cases the current solution produces an error trying to import the js file. In my case that was a simple blazor router where when I visit a route for example "/counter" it would try to import the script from "/counter_content/Blazor.Extensions.Logging/BrowserConsoleLogger.js". Using the navigation manager for the other case where the blazor app might be hosted in a route different than the root of the website.